### PR TITLE
Support for input variable JSS_VERIFY_SSL

### DIFF
--- a/JSSImporter.py
+++ b/JSSImporter.py
@@ -83,6 +83,11 @@ class JSSImporter(Processor):
             "description": "Password of api user, optionally set as a key in "
             "the com.github.autopkg preference file.",
         },
+        "JSS_VERIFY_SSL": {
+            "required": False,
+            "description": "If set to False, SSL verification in communication "
+            "with the JSS will be skipped. Defaults to True.",
+        },
         "category": {
             "required": False,
             "description": "Category to create/associate imported app "
@@ -462,7 +467,8 @@ class JSSImporter(Processor):
         repoUrl = self.env["JSS_URL"]
         authUser = self.env["API_USERNAME"]
         authPass = self.env["API_PASSWORD"]
-        self.j = jss.JSS(url=repoUrl, user=authUser, password=authPass)
+        sslVerify = self.env.get("JSS_VERIFY_SSL", True)
+        self.j = jss.JSS(url=repoUrl, user=authUser, password=authPass, ssl_verify=sslVerify)
         self.pkg_name = os.path.basename(self.env["pkg_path"])
         self.prod_name = self.env["prod_name"]
         self.version = self.env["version"]

--- a/README.md
+++ b/README.md
@@ -192,6 +192,15 @@ Substitution variables available in templates include:
 - ```%POLICY_CATEGORY%```: The value of ```%policy_category%```, if specified, or "Unknown", if not-this is what the JSS will assign anyway.
 - ```%JSSINVENTORY_NAME%```: If you want to override the default guessing of the "Application Title" for a smart group, use this along with an input variable of jss_inventory_name
 
+SSL
+===
+
+If you have issues with certificate validation (either a self-signed certificate on a JSS instance, or issues due to Python's weak SSL support in 2.x on OS X), there is an additional boolean preference you can set to disable SSL verification:
+
+    defaults write com.github.autopkg JSS_VERIFY_SSL -bool false
+
+This value defaults to true.
+
 Comments/Questions/Ideas
 =================
 


### PR DESCRIPTION
In my test instance, I have a self-signed cert. While I might be able to convince Requests that the cert is trusted in OS X's keychain, I would imagine that a server depending on SNI would also have issues (given Python's SSL support in 2.7 being still lacking on OS X). Requests still cannot do SNI unless additional SSL libraries are provided, according to their docs.

Anyway, to alleviate these issues I added a simple boolean pref that supports passing the appropriate option to your jss module's `ssl_verify` function arg for `JSS()`. Defaults to True, of course, if it's not specified.
