### PR TITLE
Add SITE_ID and SITE_NAME as an variable for PolicyTemplates.

### DIFF
--- a/JSSImporter.py
+++ b/JSSImporter.py
@@ -176,12 +176,10 @@ class JSSImporter(Processor):
         "site_id": {
           "required": False,
           "description": "ID of the target Site",
-          "default": "-1",
         },
         "site_name": {
           "required": False,
           "description": "Name of the target Site",
-          "default": "None",
         },
     }
     output_variables = {
@@ -237,8 +235,10 @@ class JSSImporter(Processor):
         if self.package is not None:
             replace_dict['%PKG_NAME%'] = self.package.name
         replace_dict['%PROD_NAME%'] = self.env.get('prod_name')
-        replace_dict['%SITE_ID%'] = self.env.get('site_id')
-        replace_dict['%SITE_NAME%'] = self.env.get('site_name')
+        if self.env.get('site_id'):
+            replace_dict['%SITE_ID%'] = self.env.get('site_id')
+        if self.env.get('site_name'):
+            replace_dict['%SITE_NAME%'] = self.env.get('site_name')
         replace_dict['%SELF_SERVICE_DESCRIPTION%'] = self.env.get(
             'self_service_description')
         replace_dict['%SELF_SERVICE_ICON%'] = self.env.get(
@@ -435,6 +435,10 @@ class JSSImporter(Processor):
         """
         # Build the template group object
         self.replace_dict['%group_name%'] = group['name']
+        if group.get('site_id'):
+            self.replace_dict['%site_id%'] = group.get('site_id')
+        if group.get('site_name'):
+            self.replace_dict['%site_name%'] = group.get('site_name')
         computer_group = self._update_or_create_new(
             jss.ComputerGroup, group["template_path"],
             update_env="jss_group_updated", added_env="jss_group_added")

--- a/JSSImporter.py
+++ b/JSSImporter.py
@@ -173,6 +173,16 @@ class JSSImporter(Processor):
             "Please see the README for more information.",
             "default": '',
         },
+        "site_id": {
+          "required": False,
+          "description": "ID of the target Site",
+          "default": "-1",
+        },
+        "site_name": {
+          "required": False,
+          "description": "Name of the target Site",
+          "default": "None",
+        },
     }
     output_variables = {
         "jss_category_added": {
@@ -227,6 +237,8 @@ class JSSImporter(Processor):
         if self.package is not None:
             replace_dict['%PKG_NAME%'] = self.package.name
         replace_dict['%PROD_NAME%'] = self.env.get('prod_name')
+        replace_dict['%SITE_ID%'] = self.env.get('site_id')
+        replace_dict['%SITE_NAME%'] = self.env.get('site_name')
         replace_dict['%SELF_SERVICE_DESCRIPTION%'] = self.env.get(
             'self_service_description')
         replace_dict['%SELF_SERVICE_ICON%'] = self.env.get(

--- a/example_templates/PolicyTemplate.xml
+++ b/example_templates/PolicyTemplate.xml
@@ -1,5 +1,10 @@
 <policy>
     <general>
+				<!-- Enable ID or Name for a Site-based Policy
+        <site>
+            <id>%SITE_ID%</id>
+            <name>%SITE_NAME%</name>
+        </site> -->
         <name>Install Latest %PROD_NAME%</name>
         <enabled>true</enabled>
         <frequency>Ongoing</frequency>

--- a/example_templates/SmartGroupTemplate.xml
+++ b/example_templates/SmartGroupTemplate.xml
@@ -1,4 +1,9 @@
 <computer_group>
+    <!-- Enable ID or Name for a Site-based Group
+    <site>
+        <id>%site_id%</id>
+        <name>%site_name%</name>
+    </site> -->
     <name>%group_name%</name>
     <is_smart>true</is_smart>
     <criteria>


### PR DESCRIPTION
Works here(TM) but give it a test before Adding it to your Branch :)

Both values defaults to a "siteless" JSS having the Site "None".

To use this feature add

```xml
<key>site_id</key>
<string>1</string>
<key>site_name</key>
<string>Your Site</string>
```
as Arguments to your JSSImporter processor-process just like "category" or "policy_category".

Within your PolicyTemplate.xml you have to put a few additional xml-tags under <general> as shown here:
```xml
<policy>
  <general>
    <site>
      <id>%SITE_ID%</id>
      <name>%SITE_NAME%</name>
    </site>
  </general>
</policy>
```
This will make some trouble if you add a Policy to Site X and scope it to a Group in Site Y.
Those few lines will asure that you don't have to put multiple PolicyTemplates for different Sites into one recipe.

Works here(TM) but give it a test before Adding it to your Branch :)