### PR TITLE
Add summary_results for use with autopkg 0.4.3.

### DIFF
--- a/JSSImporter.py
+++ b/JSSImporter.py
@@ -221,6 +221,9 @@ class JSSImporter(Processor):
         "jss_icon_uploaded": {
             "description": "True if an icon was uploaded."
         },
+        "jss_importer_summary_result": {
+            "description": "Description of interesting results."
+        },
     }
     description = __doc__
 
@@ -666,6 +669,10 @@ class JSSImporter(Processor):
                   (REQUIRED_PYTHON_JSS_VERSION, python_jss_version))
             sys.exit()
 
+        # clear any pre-exising summary result
+        if 'jss_importer_summary_result' in self.env:
+            del self.env['jss_importer_summary_result']
+        
         # pull jss recipe-specific args, prep api auth
         repoUrl = self.env["JSS_URL"]
         authUser = self.env["API_USERNAME"]
@@ -712,6 +719,15 @@ class JSSImporter(Processor):
         self.handle_icon()
         # Done with DPs, unmount them.
         self.j.distribution_points.umount()
+
+        if self.env["jss_package_added"] or self.env["jss_package_updated"]:
+            self.env['jss_importer_summary_result'] = {
+                'summary_text': ('The following items '
+                                 'were importerd into the JSS:'),
+                'data': {
+                    'Package': self.package.name,
+                }
+            }
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hey Shea,
This is just a starting point, you'll probably want to customize this a bit more (maybe including the category), but here are the basic bones to take advantage of the new _summary_report feature that's in AutoPkg 0.4.3.

Basically it will display something similar to this at the end of an `autopkg run ...`

```
The following items were importerd into the JSS:
    Package                         
    ------------                         
    AdobeFlashPlayer-17.0.0.134.pkg
    MySweetApp-4.0.2.pkg    
```

And add an item to the `--report-plist` for AutoPkgr to take advantage of.
