### PR TITLE
Add the NAME as a usuable variable in .xml templates

### DIFF
--- a/JSSImporter.py
+++ b/JSSImporter.py
@@ -196,6 +196,10 @@ class JSSImporter(Processor):
           "required": False,
           "description": "Name of the target Site",
         },
+        "NAME": {
+          "required": False,
+          "description": "Name of the current Package",
+				},
     }
     output_variables = {
         "jss_changed_objects": {
@@ -226,6 +230,8 @@ class JSSImporter(Processor):
             replace_dict['SITE_ID'] = self.env.get('site_id')
         if self.env.get('site_name'):
             replace_dict['SITE_NAME'] = self.env.get('site_name')
+        if self.env.get('NAME'):
+            replace_dict['NAME'] = self.env.get('NAME')
         replace_dict['SELF_SERVICE_DESCRIPTION'] = self.env.get(
             'self_service_description')
         replace_dict['SELF_SERVICE_ICON'] = self.env.get(


### PR DESCRIPTION
This will give you the following feature:
```
<computer_group>
  <name>%group_name%</name>
  <is_smart>true</is_smart>
  <criteria>
    <criterion>
      <name>Computer Group</name>
      <priority>0</priority>
      <and_or>and</and_or>
      <search_type>member of</search_type>
      <value>Install_%NAME%</value>
    </criterion>
</computer_group>
```

-> No more editing of the InstallGroup.xml file per Recipe/Software