### PR TITLE
added option to force policy state

### DIFF
--- a/JSSImporter.py
+++ b/JSSImporter.py
@@ -159,7 +159,7 @@ class JSSImporter(Processor):
                 "If set to False JSSImporter will not override the policy "
                 "enabled state. This allows creating new policies in a default "
                 "state and then going and manually enabling them in the JSS "
-                "Boolean, defaults to 'True',
+                "Boolean, defaults to 'True'",
             "default": True,
         },
         "os_requirements": {

--- a/JSSImporter.py
+++ b/JSSImporter.py
@@ -153,6 +153,15 @@ class JSSImporter(Processor):
                 "Category to create/associate policy with. Defaults"
                 " to 'No category assigned'.",
         },
+        "force_policy_state": {
+            "required": False,
+            "description":
+                "If set to False JSSImporter will not override the policy "
+                "enabled state. This allows creating new policies in a default "
+                "state and then going and manually enabling them in the JSS "
+                "Boolean, defaults to 'True',
+            "default": True,
+        },
         "os_requirements": {
             "required": False,
             "description":
@@ -823,6 +832,9 @@ class JSSImporter(Processor):
                     "self_service/self_service_icon")
                 if icon_xml is not None:
                     self.add_icon_to_policy(recipe_object, icon_xml)
+                if not self.env.get('force_policy_state'):
+                    state = existing_object.find('general/enabled').text
+                    recipe_object.find('general/enabled').text = state
             self.add_scope_to_policy(recipe_object)
             self.add_scripts_to_policy(recipe_object)
             self.add_package_to_policy(recipe_object)


### PR DESCRIPTION
In our current workflow we like to create all policies for software deployments in a disabled state and then go in and manually check them. This allows us to not worry too much about what policies are created in the JSS by AutoPkg because we know they will default to disabled.

This might be useful for others, so I added a param with a default that does not change the current behavior.